### PR TITLE
Update ABC import

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -115,7 +115,6 @@ if options.setuptools_to_dir is not None:
     setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
-import setuptools
 import pkg_resources
 
 # This does not (always?) update the default working set.  We will

--- a/l18n/compat.py
+++ b/l18n/compat.py
@@ -1,0 +1,6 @@
+try:
+    # python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # python 2
+    from collections import MutableMapping

--- a/l18n/translation.py
+++ b/l18n/translation.py
@@ -2,7 +2,7 @@ import os
 import gettext
 import bisect
 from locale import getdefaultlocale
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from copy import copy, deepcopy
 
 import six

--- a/l18n/translation.py
+++ b/l18n/translation.py
@@ -2,10 +2,11 @@ import os
 import gettext
 import bisect
 from locale import getdefaultlocale
-from collections.abc import MutableMapping
 from copy import copy, deepcopy
 
 import six
+
+from .compat import MutableMapping
 
 
 class Trans(object):

--- a/maker/l18n_maker/helpers.py
+++ b/maker/l18n_maker/helpers.py
@@ -4,8 +4,8 @@ import os
 import zipfile
 
 import requests
-
 from six import BytesIO
+
 from .settings import CLDR_DATA_URL
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'cldr_db')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,8 +3,8 @@ from __future__ import print_function
 import os
 import sys
 import shutil
-from imp import reload
 
+from .compat import reload
 from .maker import build
 
 

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,6 @@
+try:
+    # python 3
+    from importlib import reload
+except ImportError:
+    # python 2
+    from imp import reload


### PR DESCRIPTION
Importing the ABCs from 'collections' doesn't work in python 3.9.