### PR TITLE
bdist_wininst was removed I guess?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,10 @@ for cmd in ('sdist', 'bdist', 'bdist_egg', 'bdist_rpm', 'bdist_wininst'):
                              cmd)
     except (AttributeError, ImportError):
         # That's a distutils command (bdist)
-        cmd_module = getattr(__import__('distutils.command', fromlist=[cmd]),
-                             cmd)
+        try:
+            cmd_module = getattr(__import__('distutils.command', fromlist=[cmd]), cmd)
+        except AttributeError:
+            continue
 
     base_class = getattr(cmd_module, cmd)
 


### PR DESCRIPTION
After upgrading to python 3.10.0, this package is no longer installable via `python setup.py install`and poetry. Installing it via pip does work somehow though. Skipping bdist_wininst fixed it for me.